### PR TITLE
rtorrent_exporter: Add Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.13
+
+ENV GO111MODULE=on
+
+EXPOSE 9135
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go install -v ./...
+
+ENTRYPOINT ["rtorrent_exporter"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ $ ./rtorrent_exporter -rtorrent.addr http://127.0.0.1/RPC2
 2016/03/09 17:39:40 starting rTorrent exporter on ":9135" for server "http://127.0.0.1/RPC2"
 ```
 
+Docker
+------
+
+```
+docker build -t rtorrent_exporter .
+docker run --rm -d -p 9135:9135 rtorrent_exporter -rtorrent.addr "http://127.0.0.1/RPC2"
+```
+
 Sample
 ------
 


### PR DESCRIPTION
Revival of mdlayher/rtorrent_exporter#2 to add a Dockerfile for rtorrent_exporter.

This Dockerfile takes a simpler approach than #2 and doesn't try to make any other changes to the binary. Aside from .travis.yml, this is literally just the Dockerfile.

I updated .travis.yml to be inline with the current version of golang that I chose for this Dockerfile.