### PR TITLE
rtorrent_exporter: Fixes test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 go:
-  - 1.6
+  - 1.13
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
+  - go get golang.org/x/lint/golint
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/golang/lint/golint
 before_script:
   - go get -d ./...
 script:

--- a/rtorrentexporter_test.go
+++ b/rtorrentexporter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func testCollector(t *testing.T, collector prometheus.Collector) []byte {
@@ -15,7 +16,7 @@ func testCollector(t *testing.T, collector prometheus.Collector) []byte {
 	}
 	defer prometheus.Unregister(collector)
 
-	promServer := httptest.NewServer(prometheus.Handler())
+	promServer := httptest.NewServer(promhttp.Handler())
 	defer promServer.Close()
 
 	resp, err := http.Get(promServer.URL)


### PR DESCRIPTION
Similar to #6. prometheus.Handler was deprecated by promhttp.Handler.

```bash
rtorrent_exporter $ go test
# github.com/mdlayher/rtorrent_exporter [github.com/mdlayher/rtorrent_exporter.test]
./rtorrentexporter_test.go:18:35: undefined: prometheus.Handler
FAIL	github.com/mdlayher/rtorrent_exporter [build failed]
```