### PR TITLE
rtorrent_exporter: Add download_total_bytes and upload_total_bytes metrics.

### DIFF
--- a/downloadscollector_test.go
+++ b/downloadscollector_test.go
@@ -27,7 +27,8 @@ func TestDownloadsCollector(t *testing.T) {
 				files: map[string]string{
 					hashA: "foo",
 				},
-				rate: 1024,
+				rate:  1024,
+				total: 1024,
 			},
 			matches: []*regexp.Regexp{
 				regexp.MustCompile(`rtorrent_downloads 1`),
@@ -41,7 +42,9 @@ func TestDownloadsCollector(t *testing.T) {
 				regexp.MustCompile(`rtorrent_downloads_active 1`),
 
 				regexp.MustCompile(`rtorrent_downloads_download_rate_bytes{info_hash="AAAA",name="foo"} 1024`),
+				regexp.MustCompile(`rtorrent_downloads_download_total_bytes{info_hash="AAAA",name="foo"} 1024`),
 				regexp.MustCompile(`rtorrent_downloads_upload_rate_bytes{info_hash="AAAA",name="foo"} 1024`),
+				regexp.MustCompile(`rtorrent_downloads_upload_total_bytes{info_hash="AAAA",name="foo"} 1024`),
 			},
 		},
 		{
@@ -57,7 +60,8 @@ func TestDownloadsCollector(t *testing.T) {
 					hashB: "bar",
 					hashC: "baz",
 				},
-				rate: 2048,
+				rate:  2048,
+				total: 2048,
 			},
 			matches: []*regexp.Regexp{
 				regexp.MustCompile(`rtorrent_downloads 3`),
@@ -71,11 +75,17 @@ func TestDownloadsCollector(t *testing.T) {
 				regexp.MustCompile(`rtorrent_downloads_active 3`),
 
 				regexp.MustCompile(`rtorrent_downloads_download_rate_bytes{info_hash="AAAA",name="foo"} 2048`),
+				regexp.MustCompile(`rtorrent_downloads_download_total_bytes{info_hash="AAAA",name="foo"} 2048`),
 				regexp.MustCompile(`rtorrent_downloads_upload_rate_bytes{info_hash="AAAA",name="foo"} 2048`),
+				regexp.MustCompile(`rtorrent_downloads_upload_total_bytes{info_hash="AAAA",name="foo"} 2048`),
 				regexp.MustCompile(`rtorrent_downloads_download_rate_bytes{info_hash="BBBB",name="bar"} 2048`),
+				regexp.MustCompile(`rtorrent_downloads_download_total_bytes{info_hash="BBBB",name="bar"} 2048`),
 				regexp.MustCompile(`rtorrent_downloads_upload_rate_bytes{info_hash="BBBB",name="bar"} 2048`),
+				regexp.MustCompile(`rtorrent_downloads_upload_total_bytes{info_hash="BBBB",name="bar"} 2048`),
 				regexp.MustCompile(`rtorrent_downloads_download_rate_bytes{info_hash="CCCC",name="baz"} 2048`),
+				regexp.MustCompile(`rtorrent_downloads_download_total_bytes{info_hash="CCCC",name="baz"} 2048`),
 				regexp.MustCompile(`rtorrent_downloads_upload_rate_bytes{info_hash="CCCC",name="baz"} 2048`),
+				regexp.MustCompile(`rtorrent_downloads_upload_total_bytes{info_hash="CCCC",name="baz"} 2048`),
 			},
 		},
 	}
@@ -101,6 +111,7 @@ type testDownloadsSource struct {
 	downloads []string
 	files     map[string]string
 	rate      int
+	total     int
 }
 
 func (ds *testDownloadsSource) All() ([]string, error)        { return ds.downloads, nil }
@@ -116,5 +127,7 @@ func (ds *testDownloadsSource) Active() ([]string, error)     { return ds.downlo
 func (ds *testDownloadsSource) BaseFilename(infoHash string) (string, error) {
 	return ds.files[infoHash], nil
 }
-func (ds *testDownloadsSource) DownloadRate(_ string) (int, error) { return ds.rate, nil }
-func (ds *testDownloadsSource) UploadRate(_ string) (int, error)   { return ds.rate, nil }
+func (ds *testDownloadsSource) DownloadRate(_ string) (int, error)  { return ds.rate, nil }
+func (ds *testDownloadsSource) DownloadTotal(_ string) (int, error) { return ds.total, nil }
+func (ds *testDownloadsSource) UploadRate(_ string) (int, error)    { return ds.rate, nil }
+func (ds *testDownloadsSource) UploadTotal(_ string) (int, error)   { return ds.total, nil }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,10 @@ module github.com/mdlayher/rtorrent_exporter
 go 1.13
 
 require (
-	github.com/kolo/xmlrpc v0.0.0-20190909154602-56d5ec7c422e // indirect
-	github.com/mdlayher/rtorrent v0.0.0-20190602193728-e6d0c11730c7
+	github.com/mdlayher/rtorrent v0.0.0-20191011143022-58e7d496034e
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/common v0.7.0 // indirect
 	github.com/prometheus/procfs v0.0.5 // indirect
-	golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13 // indirect
+	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mdlayher/rtorrent v0.0.0-20190602193728-e6d0c11730c7 h1:3576snTkyVrXsvWMCHPZW+BcZScsURLSaaINED6QGts=
 github.com/mdlayher/rtorrent v0.0.0-20190602193728-e6d0c11730c7/go.mod h1:/b7OFOB73g48SebJBe7XUsuRkV3ZcM2bFPs3BQvg8xE=
+github.com/mdlayher/rtorrent v0.0.0-20191011143022-58e7d496034e h1:U5Ad0UsquguX8AXoV0FRdoUbRwyGAOCxgpHH63KJRpU=
+github.com/mdlayher/rtorrent v0.0.0-20191011143022-58e7d496034e/go.mod h1:pu+ner2JS5stk0GIzbqha84Sq9uOU14p352NKWJuGM4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -80,8 +82,12 @@ golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 h1:4y9KwBHBgBNwDbtu44R5o1fdO
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13 h1:/zi0zzlPHWXYXrO1LjNRByFu8sdGgCkj2JLDdBIB84k=
 golang.org/x/sys v0.0.0-20190919044723-0c1ff786ef13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Depends on https://github.com/mdlayher/rtorrent/pull/3. Includes changes from https://github.com/mdlayher/rtorrent_exporter/pull/7.

Example:
```bash
# HELP rtorrent_downloads_download_total_bytes Total Bytes downloaded.                                                              
# TYPE rtorrent_downloads_download_total_bytes gauge
rtorrent_downloads_download_total_bytes{info_hash="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",name="ubuntu.iso"} 3.317408117e+09                                                                                                                                
rtorrent_downloads_download_total_bytes{info_hash="BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",name="archlinux.iso"} 6.4112527806e+10                                                                                                                                                                                            
# HELP rtorrent_downloads_upload_total_bytes Total Bytes uploaded.                                                                  
# TYPE rtorrent_downloads_upload_total_bytes gauge
rtorrent_downloads_upload_total_bytes{info_hash="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",name="ubuntu.iso"} 4.387568983e+10                                                                                                                                  
rtorrent_downloads_upload_total_bytes{info_hash="BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",name="archlinux.iso"} 2.53656149302e+11  
```