### PR TITLE
Add support for scgi:// URL scheme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,21 @@ Usage of ./rtorrent_exporter:
         URL path for surfacing collected metrics (default "/metrics")
 ```
 
-An example of using `rtorrent_exporter`:
+Examples of using `rtorrent_exporter`:
 
 ```
 $ ./rtorrent_exporter -rtorrent.addr http://127.0.0.1/RPC2
 2016/03/09 17:39:40 starting rTorrent exporter on ":9135" for server "http://127.0.0.1/RPC2"
+```
+
+```
+$ ./rtorrent_exporter -rtorrent.addr scgi://127.0.0.1:5000
+2016/03/09 17:39:40 starting rTorrent exporter on ":9135" for server "scgi://127.0.0.1:5000"
+```
+
+```
+$ ./rtorrent_exporter -rtorrent.addr scgi:///home/user/rtorrent/rpc.socket
+2016/03/09 17:39:40 starting rTorrent exporter on ":9135" for server "scgi:///home/user/rtorrent/rpc.socket"
 ```
 
 Docker

--- a/scgi.go
+++ b/scgi.go
@@ -1,0 +1,119 @@
+package rtorrentexporter
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const headersFormat = "CONTENT_LENGTH\x00%d\x00SCGI\x001\x00"
+const statusHeaderPrefix = "Status:"
+
+type body struct {
+	io.ReadCloser
+	conn net.Conn
+}
+
+func (b *body) Close() error {
+	defer b.conn.Close()
+	return b.ReadCloser.Close()
+}
+
+// SCGITransport implements RoundTripper for the 'scgi' protocol.
+//
+// This is a minimal, rTorrent specific implementation.
+type SCGITransport struct {
+	// DialContext specifies the dial function for creating connections.
+	// If DialContext is nil then the transport dials using net.Dialer.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+// RoundTrip implements the net/http.RoundTripper interface.
+//
+// A new connection is established for each handled request.
+func (t SCGITransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	conn, err := t.dial(req.Context(), req.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = t.writeRequest(req, conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	resp, err := t.readResponse(req, conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	// Close the connection after body is consumed
+	resp.Body = &body{
+		ReadCloser: resp.Body,
+		conn:       conn,
+	}
+	return resp, nil
+}
+
+var zeroDialer net.Dialer
+
+// dial creates a TCP or UNIX socket connection, depending on the URL format.
+func (t SCGITransport) dial(ctx context.Context, url *url.URL) (net.Conn, error) {
+	if url.Scheme != "scgi" {
+		return nil, fmt.Errorf("unsupported protocol scheme %q", url.Scheme)
+	}
+
+	var network, addr string
+	if url.Host != "" {
+		network = "tcp"
+		addr = url.Host
+	} else {
+		network = "unix"
+		addr = url.Path
+	}
+
+	if t.DialContext != nil {
+		return t.DialContext(ctx, network, addr)
+	}
+	return zeroDialer.DialContext(ctx, network, addr)
+}
+
+// writeRequest formats and writes the SCGI request.
+func (t SCGITransport) writeRequest(req *http.Request, conn net.Conn) error {
+	writer := bufio.NewWriter(conn)
+	headers := fmt.Sprintf(headersFormat, req.ContentLength)
+
+	if _, err := writer.WriteString(fmt.Sprintf("%d:%s,", len(headers), headers)); err != nil {
+		return err
+	}
+
+	if req.Body != nil {
+		defer req.Body.Close()
+		if _, err := io.Copy(writer, req.Body); err != nil {
+			return err
+		}
+	}
+
+	return writer.Flush()
+}
+
+// readResponse reads and parses the SCGI response.
+func (t SCGITransport) readResponse(req *http.Request, conn net.Conn) (*http.Response, error) {
+	reader := bufio.NewReader(conn)
+	status, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.HasPrefix(status, statusHeaderPrefix) {
+		return nil, fmt.Errorf("expected %q header, received %q", statusHeaderPrefix, status)
+	}
+	status = strings.Replace(status, statusHeaderPrefix, req.Proto, 1)
+	reader = bufio.NewReader(io.MultiReader(strings.NewReader(status), reader))
+	return http.ReadResponse(reader, req)
+}

--- a/scgi_test.go
+++ b/scgi_test.go
@@ -1,0 +1,134 @@
+package rtorrentexporter
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestSCGITransport(t *testing.T) {
+	transport := &SCGITransport{}
+
+	t.Run("dial", func(t *testing.T) {
+		var dialNetwork string
+		var dialAddr string
+		transport.DialContext = func(_ context.Context, network, addr string) (net.Conn, error) {
+			dialNetwork = network
+			dialAddr = addr
+			return nil, nil
+		}
+
+		t.Run("withHost", func(t *testing.T) {
+			requestURL, _ := url.Parse("scgi://host:8080")
+			_, err := transport.dial(context.TODO(), requestURL)
+			if err != nil {
+				t.Fatalf("dial returned: %s", err)
+			}
+
+			assertEqual(t, "tcp", dialNetwork)
+			assertEqual(t, "host:8080", dialAddr)
+		})
+
+		t.Run("withoutHost", func(t *testing.T) {
+			requestURL, _ := url.Parse("scgi:///socket")
+			_, err := transport.dial(context.TODO(), requestURL)
+			if err != nil {
+				t.Fatalf("dial returned: %s", err)
+			}
+
+			assertEqual(t, "unix", dialNetwork)
+			assertEqual(t, "/socket", dialAddr)
+		})
+
+		t.Run("withBadScheme", func(t *testing.T) {
+			requestURL, _ := url.Parse("http://")
+			_, err := transport.dial(context.TODO(), requestURL)
+			if err == nil {
+				t.Fatalf("expected dial to return an error")
+			}
+
+			assertEqual(t, `unsupported protocol scheme "http"`, err.Error())
+		})
+	})
+
+	t.Run("writeRequest", func(t *testing.T) {
+		channel := make(chan []byte)
+		server := func(conn net.Conn) {
+			buffer := make([]byte, 128)
+			n, _ := conn.Read(buffer)
+			conn.Close()
+			channel <- buffer[:n]
+		}
+
+		t.Run("withBody", func(t *testing.T) {
+			input, output := net.Pipe()
+			defer input.Close()
+			go server(output)
+
+			body := `<?xml version="1.0" encoding="UTF-8"?>`
+			request := httptest.NewRequest("POST", "scgi://", bytes.NewBufferString(body))
+			if err := transport.writeRequest(request, input); err != nil {
+				t.Fatalf("writeRequest returned: %s", err)
+			}
+
+			assertEqual(t, "25:CONTENT_LENGTH\x0038\x00SCGI\x001\x00,"+body, string(<-channel))
+		})
+
+		t.Run("withoutBody", func(t *testing.T) {
+			input, output := net.Pipe()
+			defer input.Close()
+			go server(output)
+
+			request := httptest.NewRequest("POST", "scgi://", nil)
+			if err := transport.writeRequest(request, input); err != nil {
+				t.Fatalf("writeRequest returned: %s", err)
+			}
+
+			assertEqual(t, "24:CONTENT_LENGTH\x000\x00SCGI\x001\x00,", string(<-channel))
+		})
+	})
+
+	t.Run("readResponse", func(t *testing.T) {
+		server := func(conn net.Conn, data []byte) {
+			conn.Write(data)
+			conn.Close()
+		}
+
+		t.Run("withStatus", func(t *testing.T) {
+			input, output := net.Pipe()
+			defer output.Close()
+			go server(input, []byte("Status: 200 OK\r\nContent-Length: 0\r\n\r\n"))
+
+			request := httptest.NewRequest("POST", "scgi://", nil)
+			response, err := transport.readResponse(request, output)
+			if err != nil {
+				t.Fatalf("readResponse returned: %s", err)
+			}
+
+			assertEqual(t, "200 OK", response.Status)
+		})
+
+		t.Run("withoutStatus", func(t *testing.T) {
+			input, output := net.Pipe()
+			defer output.Close()
+			go server(input, []byte("HTTP/1.1 200 OK\r\n"))
+
+			request := httptest.NewRequest("POST", "scgi://", nil)
+			_, err := transport.readResponse(request, output)
+			if err == nil {
+				t.Fatalf("expected readResponse to return an error")
+			}
+
+			assertEqual(t, `expected "Status:" header, received "HTTP/1.1 200 OK\r\n"`, err.Error())
+		})
+	})
+}
+
+func assertEqual(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		t.Fatalf("%q != %q", expected, actual)
+	}
+}


### PR DESCRIPTION
Introduce SCGI transport to support direct rTorrent connections, e.g.:
1) Over TCP socket:

```
$ cat ~/.rtorrent.rc
network.scgi.open_port = 127.0.0.1:5000
$ rtorrent_exporter -rtorrent.addr scgi://127.0.0.1:5000
```

2) Over UNIX socket:

```
$ cat ~/.rtorrent.rc
network.scgi.open_local = /home/user/rtorrent/rpc.socket
$ rtorrent_exporter -rtorrent.addr scgi:///home/user/rtorrent/rpc.socket
```